### PR TITLE
Add jshell

### DIFF
--- a/languages/java.json
+++ b/languages/java.json
@@ -1,0 +1,14 @@
+{
+    "language": "java",
+    "compiled": false,
+    "compiler_exec": "",
+    "compiler_flags": [
+    ],
+    "exec": "jshell",
+    "exec_flags": [
+    ],
+    "known_naming": [
+        "java"
+    ],
+    "file_extension": ".java"
+}


### PR DESCRIPTION
For java, you don't need to compile. The JDK, including the openJDK, comes with an interpreter called jshell.
see: https://subscription.packtpub.com/book/application_development/9781789131895/1/ch01lvl1sec12/executing-jshell